### PR TITLE
Add exercise logging (calories burned)

### DIFF
--- a/food_tracking/models.py
+++ b/food_tracking/models.py
@@ -119,6 +119,8 @@ class Consumption(models.Model):
         """Icon for the entry; ad-hoc estimates use a generic icon."""
         if self.food is not None:
             return self.food.icon
+        if self.calories is not None and self.calories < 0:
+            return "🔥"
         return "🍽️"
 
     def __str__(self) -> str:

--- a/food_tracking/static/food_tracking/css/styles.css
+++ b/food_tracking/static/food_tracking/css/styles.css
@@ -390,3 +390,41 @@
 }
 
 /* Existing checkered-blue table styles should be inherited from music/css/styles.css */
+
+/* ---------------------------------------------------------------- */
+/* Log exercise (calories burned)                                  */
+/* ---------------------------------------------------------------- */
+.exercise-details {
+    margin-top: 12px;
+}
+
+.exercise-details summary {
+    cursor: pointer;
+    font-weight: bold;
+    color: #1976D2;
+    margin-bottom: 8px;
+}
+
+.exercise-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.exercise-row input[type="text"] {
+    flex: 1;
+    min-width: 140px;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    font-size: 15px;
+}
+
+.exercise-row input[type="number"] {
+    width: 130px;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    font-size: 15px;
+}

--- a/food_tracking/static/food_tracking/js/tracking.js
+++ b/food_tracking/static/food_tracking/js/tracking.js
@@ -303,3 +303,32 @@ function editTarget() {
         })
         .catch(() => alert('Failed to update target. Please try again.'));
 }
+
+/**
+ * Log exercise as calories burned (stored as a negative consumption).
+ */
+function logExercise() {
+    const description = document.getElementById('exercise-input').value.trim();
+    const burned = document.getElementById('exercise-calories').value;
+    if (!description) {
+        alert('Describe the exercise.');
+        return;
+    }
+    if (!burned || parseFloat(burned) <= 0) {
+        alert('Enter calories burned.');
+        return;
+    }
+    const formData = new FormData();
+    formData.append('description', description);
+    formData.append('calories_burned', burned);
+
+    postForm('/food/log-exercise/', formData)
+        .then(data => {
+            if (data.success) {
+                location.reload();
+            } else {
+                alert('Error: ' + (data.error || 'Could not log exercise.'));
+            }
+        })
+        .catch(() => alert('Failed to log exercise. Please try again.'));
+}

--- a/food_tracking/templates/food_tracking/home.html
+++ b/food_tracking/templates/food_tracking/home.html
@@ -4,8 +4,8 @@
 {% block title %}Food Tracker{% endblock %}
 
 {% block extraheaders %}
-<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=9">
-<script src="{% static 'food_tracking/js/tracking.js' %}?v=8"></script>
+<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=10">
+<script src="{% static 'food_tracking/js/tracking.js' %}?v=9"></script>
 {% endblock %}
 
 {% block content %}
@@ -16,7 +16,7 @@
     <div class="budget-banner">
         <div class="budget-cell">
             <div class="budget-value">{{ today_total_calories|floatformat:0 }}</div>
-            <div class="budget-label">eaten</div>
+            <div class="budget-label">net</div>
         </div>
         <div class="budget-cell">
             <div class="budget-value {% if remaining_calories < 0 %}over-budget{% endif %}"
@@ -58,6 +58,15 @@
                     <input type="number" id="fraction-input" min="0.01" max="1" step="0.05" value="0.25">
                 </label>
                 <button class="estimate-button" onclick="estimateFromRecipe()">Estimate</button>
+            </div>
+        </details>
+
+        <details class="exercise-details">
+            <summary>🔥 Log exercise</summary>
+            <div class="exercise-row">
+                <input type="text" id="exercise-input" placeholder="e.g. 30 min run">
+                <input type="number" id="exercise-calories" min="1" step="1" placeholder="Calories burned">
+                <button class="estimate-button" onclick="logExercise()">Log</button>
             </div>
         </details>
 

--- a/food_tracking/test_models.py
+++ b/food_tracking/test_models.py
@@ -265,3 +265,22 @@ class AdHocConsumptionModelTests(TestCase):
             user=self.user, food=None, description="Tacos", calories=Decimal("400")
         )
         self.assertIn("Tacos", str(consumption))
+
+
+class ExerciseConsumptionModelTests(TestCase):
+    """Tests for negative-calorie (exercise) consumptions."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username="exmodeluser", password="x")
+
+    def test_negative_consumption_uses_fire_icon(self):
+        consumption = Consumption.objects.create(
+            user=self.user,
+            food=None,
+            description="30 min run",
+            calories=Decimal("-300"),
+        )
+        self.assertEqual(consumption.display_icon(), "🔥")
+        self.assertEqual(consumption.display_name(), "30 min run")
+        self.assertEqual(consumption.total_calories(), Decimal("-300"))

--- a/food_tracking/test_views.py
+++ b/food_tracking/test_views.py
@@ -706,3 +706,80 @@ class EstimateViewErrorPathTests(TestCase):
             reverse("food_tracking:set_target"), {"daily_calorie_target": "1800"}
         )
         self.assertEqual(response.status_code, 500)
+
+
+class LogExerciseViewTests(TestCase):
+    """Tests for logging exercise as negative-calorie consumptions."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username="exuser", password="testpass")
+
+    def setUp(self):
+        self.client = Client()
+        self.client.login(username="exuser", password="testpass")
+
+    def test_requires_login(self):
+        self.client.logout()
+        response = self.client.post(reverse("food_tracking:log_exercise"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response.url)
+
+    def test_requires_post(self):
+        response = self.client.get(reverse("food_tracking:log_exercise"))
+        self.assertEqual(response.status_code, 405)
+
+    def test_logs_negative_consumption(self):
+        response = self.client.post(
+            reverse("food_tracking:log_exercise"),
+            {"description": "30 min run", "calories_burned": "300"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["success"])
+        consumption = Consumption.objects.get(user=self.user, description="30 min run")
+        self.assertIsNone(consumption.food)
+        self.assertEqual(consumption.calories, Decimal("-300"))
+        self.assertEqual(consumption.total_calories(), Decimal("-300"))
+
+    def test_missing_description_returns_400(self):
+        response = self.client.post(
+            reverse("food_tracking:log_exercise"), {"calories_burned": "200"}
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_invalid_calories_returns_400(self):
+        response = self.client.post(
+            reverse("food_tracking:log_exercise"),
+            {"description": "run", "calories_burned": "abc"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_non_positive_calories_returns_400(self):
+        response = self.client.post(
+            reverse("food_tracking:log_exercise"),
+            {"description": "run", "calories_burned": "0"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    @patch("food_tracking.views.Consumption.objects.create")
+    def test_unexpected_error_returns_500(self, mock_create):
+        mock_create.side_effect = RuntimeError("boom")
+        response = self.client.post(
+            reverse("food_tracking:log_exercise"),
+            {"description": "run", "calories_burned": "200"},
+        )
+        self.assertEqual(response.status_code, 500)
+
+    def test_exercise_increases_remaining(self):
+        CalorieTarget.objects.create(user=self.user, daily_calorie_target=2000)
+        Consumption.objects.create(
+            user=self.user, food=None, description="Lunch", calories=Decimal("800")
+        )
+        self.client.post(
+            reverse("food_tracking:log_exercise"),
+            {"description": "run", "calories_burned": "300"},
+        )
+        response = self.client.get(reverse("food_tracking:home"))
+        # net = 800 - 300 = 500; remaining = 2000 - 500 = 1500
+        self.assertEqual(response.context["today_total_calories"], Decimal("500"))
+        self.assertEqual(response.context["remaining_calories"], Decimal("1500"))

--- a/food_tracking/urls.py
+++ b/food_tracking/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path("estimate/", views.estimate, name="estimate"),
     path("estimate-recipe/", views.estimate_recipe, name="estimate_recipe"),
     path("log-estimate/", views.log_estimate, name="log_estimate"),
+    path("log-exercise/", views.log_exercise, name="log_exercise"),
     path("target/", views.set_target, name="set_target"),
 ]

--- a/food_tracking/views.py
+++ b/food_tracking/views.py
@@ -353,3 +353,47 @@ def set_target(request: HttpRequest) -> JsonResponse:
         return JsonResponse({"success": True, "target": target.to_dict_for_api()})
     except Exception as e:
         return JsonResponse({"success": False, "error": str(e)}, status=500)
+
+
+@login_required
+@require_http_methods(["POST"])
+def log_exercise(request: HttpRequest) -> JsonResponse:
+    """Log exercise as a negative-calorie Consumption.
+
+    The user enters calories *burned* as a positive number; we store it negated
+    so it subtracts from the day's net total.
+    """
+    try:
+        description = request.POST.get("description", "").strip()
+        burned_raw = request.POST.get("calories_burned", "")
+
+        if not description:
+            return JsonResponse(
+                {"success": False, "error": "Missing description."}, status=400
+            )
+
+        try:
+            burned = Decimal(burned_raw)
+        except (InvalidOperation, TypeError):
+            return JsonResponse(
+                {"success": False, "error": "Invalid calories."}, status=400
+            )
+
+        if burned <= 0:
+            return JsonResponse(
+                {"success": False, "error": "Calories burned must be positive."},
+                status=400,
+            )
+
+        consumption = Consumption.objects.create(
+            user=request.user,
+            food=None,
+            description=description,
+            calories=-burned,
+            notes=request.POST.get("notes", ""),
+        )
+        return JsonResponse(
+            {"success": True, "consumption": consumption.to_dict_for_api()}
+        )
+    except Exception as e:
+        return JsonResponse({"success": False, "error": str(e)}, status=500)


### PR DESCRIPTION
Lets you log exercise so it offsets the day's intake. You enter **calories burned** as a positive number; it's stored as a negative `Consumption`, so it subtracts from your net total and bumps "remaining" up.

## Changes
- **New endpoint** `POST /food/log-exercise/` (`log_exercise` view): takes `description` + `calories_burned` (positive), stores `calories = -burned`.
- **UI**: a "🔥 Log exercise" form in the quick-log panel (description + calories-burned + Log).
- **Display**: exercise rows render with a 🔥 icon; the budget tile is relabeled **"eaten" → "net"** since exercise now subtracts from it.
- **No AI involved** — Claude's estimate tool is for food, so exercise is a direct manual entry.

## Tests
- View: success, missing/invalid/non-positive validation, 500-path, and the net-math through `home`.
- Model: 🔥 icon for negative-calorie entries.
- New code fully covered; full `food_tracking` suite (99 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)