### PR TITLE
Fix photo-upload failures (resize client-side) and show real errors

### DIFF
--- a/ansible/nginx_config
+++ b/ansible/nginx_config
@@ -1,6 +1,8 @@
 server {
     listen 80;
     server_name paulcarroll.site www.paulcarroll.site 44.230.244.94;
+    # Allow food-photo uploads; the client downscales to ~150KB, but give margin.
+    client_max_body_size 10M;
     location /static/ {
         root /home/{{ username }}/source;
     }

--- a/food_tracking/static/food_tracking/js/tracking.js
+++ b/food_tracking/static/food_tracking/js/tracking.js
@@ -127,17 +127,49 @@ function logFood(foodId, quantity = 1.0) {
 /* ------------------------------------------------------------------ */
 
 /**
- * POST a FormData payload with CSRF protection and return the parsed JSON.
+ * POST a FormData payload with CSRF protection. Resolves to parsed JSON on
+ * success; otherwise rejects with an Error carrying a specific message (server
+ * error text, a 413 "too large" hint, or a network message) so the UI can tell
+ * the user what actually went wrong instead of a generic failure.
  * @param {string} url
  * @param {FormData} formData
  * @returns {Promise<Object>}
  */
-function postForm(url, formData) {
-    return fetch(url, {
-        method: 'POST',
-        headers: { 'X-CSRFToken': getCookie('csrftoken') },
-        body: formData,
-    }).then(response => response.json());
+async function postForm(url, formData) {
+    let response;
+    try {
+        response = await fetch(url, {
+            method: 'POST',
+            headers: { 'X-CSRFToken': getCookie('csrftoken') },
+            body: formData,
+        });
+    } catch (e) {
+        throw new Error('Network error — check your connection.');
+    }
+
+    // Read as text first: error responses (413, 500 pages) are often HTML.
+    const bodyText = await response.text();
+    let data = null;
+    try {
+        data = JSON.parse(bodyText);
+    } catch (e) {
+        data = null;
+    }
+
+    if (!response.ok) {
+        if (data && data.error) {
+            throw new Error(data.error);
+        }
+        if (response.status === 413) {
+            throw new Error('The photo is too large for the server to accept.');
+        }
+        throw new Error('Server error (HTTP ' + response.status + ').');
+    }
+
+    if (!data) {
+        throw new Error('Unexpected response from the server.');
+    }
+    return data;
 }
 
 /**
@@ -191,23 +223,75 @@ function handleEstimateResponse(data) {
     }
 }
 
+// Photos are downscaled to this longest-edge size before upload. Full iPhone
+// photos are 2-5 MB (rejected by the server's upload limit) and far larger than
+// the model needs; ~1024px keeps the file small and the food clearly legible.
+const MAX_IMAGE_DIMENSION = 1024;
+const IMAGE_JPEG_QUALITY = 0.8;
+
 /**
- * Estimate calories from a selected photo.
+ * Downscale/re-encode an image file to a compact JPEG Blob via canvas. Also
+ * normalizes formats (e.g. HEIC that slips through) to JPEG, which the backend
+ * accepts.
+ * @param {File} file
+ * @returns {Promise<Blob>}
+ */
+function resizeImageFile(file) {
+    return new Promise((resolve, reject) => {
+        const objectUrl = URL.createObjectURL(file);
+        const img = new Image();
+        img.onload = () => {
+            URL.revokeObjectURL(objectUrl);
+            let { width, height } = img;
+            if (width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION) {
+                if (width >= height) {
+                    height = Math.round((height * MAX_IMAGE_DIMENSION) / width);
+                    width = MAX_IMAGE_DIMENSION;
+                } else {
+                    width = Math.round((width * MAX_IMAGE_DIMENSION) / height);
+                    height = MAX_IMAGE_DIMENSION;
+                }
+            }
+            const canvas = document.createElement('canvas');
+            canvas.width = width;
+            canvas.height = height;
+            canvas.getContext('2d').drawImage(img, 0, 0, width, height);
+            canvas.toBlob(
+                blob => (blob ? resolve(blob) : reject(new Error('Could not process the photo.'))),
+                'image/jpeg',
+                IMAGE_JPEG_QUALITY
+            );
+        };
+        img.onerror = () => {
+            URL.revokeObjectURL(objectUrl);
+            reject(new Error('Could not read that photo. Try a JPEG or PNG.'));
+        };
+        img.src = objectUrl;
+    });
+}
+
+/**
+ * Estimate calories from a selected photo (downscaled before upload).
  * @param {HTMLInputElement} input - The file input.
  */
 function estimateFromPhoto(input) {
     if (!input.files || input.files.length === 0) {
         return;
     }
-    const formData = new FormData();
-    formData.append('image', input.files[0]);
-    formData.append('note', document.getElementById('text-input').value.trim());
-
-    setEstimateStatus('Estimating from photo…');
-    postForm('/food/estimate/', formData)
-        .then(handleEstimateResponse)
-        .catch(() => setEstimateStatus('Failed to estimate. Try again.'));
+    const file = input.files[0];
     input.value = '';
+
+    setEstimateStatus('Processing photo…');
+    resizeImageFile(file)
+        .then(blob => {
+            const formData = new FormData();
+            formData.append('image', blob, 'photo.jpg');
+            formData.append('note', document.getElementById('text-input').value.trim());
+            setEstimateStatus('Estimating from photo…');
+            return postForm('/food/estimate/', formData);
+        })
+        .then(handleEstimateResponse)
+        .catch(err => setEstimateStatus('Estimate failed: ' + err.message));
 }
 
 /**
@@ -225,7 +309,7 @@ function estimateFromText() {
     setEstimateStatus('Estimating…');
     postForm('/food/estimate/', formData)
         .then(handleEstimateResponse)
-        .catch(() => setEstimateStatus('Failed to estimate. Try again.'));
+        .catch(err => setEstimateStatus('Estimate failed: ' + err.message));
 }
 
 /**
@@ -245,7 +329,7 @@ function estimateFromRecipe() {
     setEstimateStatus('Estimating recipe…');
     postForm('/food/estimate-recipe/', formData)
         .then(handleEstimateResponse)
-        .catch(() => setEstimateStatus('Failed to estimate. Try again.'));
+        .catch(err => setEstimateStatus('Estimate failed: ' + err.message));
 }
 
 /**

--- a/food_tracking/templates/food_tracking/home.html
+++ b/food_tracking/templates/food_tracking/home.html
@@ -5,7 +5,7 @@
 
 {% block extraheaders %}
 <link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=9">
-<script src="{% static 'food_tracking/js/tracking.js' %}?v=8"></script>
+<script src="{% static 'food_tracking/js/tracking.js' %}?v=9"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Root cause
iPhone photos are 2–5 MB, but nginx had **no `client_max_body_size`**, so the default **1 MB** limit rejected every photo with a 413 HTML page. The client did `response.json()` on that HTML, threw, and showed the generic "Failed to estimate." — which is why *no* photo ever succeeded.

## Fix
- **Downscale photos client-side** to a ~1024px JPEG (`quality 0.8`) via canvas before upload — files drop to ~150 KB, well under any limit. Bonus: re-encodes HEIC→JPEG (backend-supported) and cuts token cost on the API call.
- **Real error messages**: `postForm` now rejects with a specific message — the server's JSON `error`, an explicit "photo is too large" on 413, or a network error — and the estimate handlers display it instead of a catch-all.
- **`client_max_body_size 10M`** added to `ansible/nginx_config` as a safety margin (takes effect after re-running the web-server playbook).

## Notes
- The client resize alone fixes the failures on the **next app deploy** (collectstatic + gunicorn restart) — no nginx change strictly required, but the nginx bump is good defense-in-depth.
- Python untouched; full `food_tracking` suite (90 tests) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)