### PR TITLE
Document the runtime/dev requirements split

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,20 @@ The current requirements.txt assumes you want Python 3.12. To install this on Ma
 brew install python@3.12
 brew services start postgresql@16
 ```
+
+## Dependencies
+
+Dependencies are split into two files, and both pin only **direct** dependencies (transitive
+dependencies are left for pip to resolve, so version bumps don't conflict with stale transitive
+pins):
+
+- `requirements.txt` — runtime dependencies for the web app and the `twilio_managers` daemons. This
+  is what the server installs (the ansible playbook installs it automatically).
+- `requirements-dev.txt` — `requirements.txt` plus dev/test/ops tooling (ansible, linters, coverage,
+  freezegun, ipython, etc.). Use this locally.
+
+For local development:
+
+```
+pip install -r requirements-dev.txt
+```


### PR DESCRIPTION
Follow-up to #143. Adds a **Dependencies** section to the README explaining that `requirements.txt` is runtime-only (installed on the server) and that local development uses `requirements-dev.txt`, and notes that both files pin only direct dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)