### PR TITLE
Make Today's Consumption table legible (mobile + desktop)

### DIFF
--- a/food_tracking/static/food_tracking/css/styles.css
+++ b/food_tracking/static/food_tracking/css/styles.css
@@ -196,6 +196,36 @@
 }
 
 /* ---------------------------------------------------------------- */
+/* Today's Consumption table                                        */
+/* ---------------------------------------------------------------- */
+/* The shared .checkered-blue rules force every cell to nowrap/ellipsis with
+   max-width:1px, which truncates the food name with "…". Let the food-name
+   column wrap fully at all widths instead of truncating. */
+.consumption-table td:first-child {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    max-width: none;
+    word-break: break-word;
+}
+
+/* On a phone there isn't room for everything: drop the Quantity column and
+   keep Calories + delete compact so the food name gets the space. */
+@media (max-width: 600px) {
+    .consumption-table th:nth-child(2),
+    .consumption-table td:nth-child(2) {
+        display: none;
+    }
+
+    .consumption-table th:nth-child(3),
+    .consumption-table td:nth-child(3) {
+        width: 1%;
+        white-space: nowrap;
+        text-align: right;
+    }
+}
+
+/* ---------------------------------------------------------------- */
 /* Daily budget banner                                              */
 /* ---------------------------------------------------------------- */
 .budget-banner {

--- a/food_tracking/templates/food_tracking/home.html
+++ b/food_tracking/templates/food_tracking/home.html
@@ -4,8 +4,8 @@
 {% block title %}Food Tracker{% endblock %}
 
 {% block extraheaders %}
-<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=12">
-<script src="{% static 'food_tracking/js/tracking.js' %}?v=12"></script>
+<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=13">
+<script src="{% static 'food_tracking/js/tracking.js' %}?v=13"></script>
 {% endblock %}
 
 {% block content %}
@@ -120,7 +120,7 @@
 
     <h2 style="margin-top: 40px;">Today's Consumption</h2>
     {% if today_consumption %}
-    <table class="checkered-blue">
+    <table class="checkered-blue consumption-table">
         <thead>
             <tr>
                 <th>Food</th>


### PR DESCRIPTION
## Summary

Long food names in the Today's Consumption table were truncated/cut off. Root cause: the shared `.checkered-blue td` rules (from the music app's CSS) apply `white-space: nowrap; text-overflow: ellipsis; overflow: hidden; max-width: 1px` to every cell.

Scoped CSS-only fix (via a new `.consumption-table` class on the home table, so Reports and the music app are untouched):

- **All widths**: the food-name column now **wraps fully** instead of truncating with `…`.
- **Mobile (≤600px)**: drop the Quantity column and keep Calories + delete compact so the name gets the space.

Verified with Playwright screenshots at 390px and 1000px — names wrap in full on both, and the desktop table keeps all four columns. Cache-buster bumped to `v=13`.