### PR TITLE
Show the daily budget as a color-coded equation

### DIFF
--- a/food_tracking/static/food_tracking/css/styles.css
+++ b/food_tracking/static/food_tracking/css/styles.css
@@ -228,39 +228,85 @@
 /* ---------------------------------------------------------------- */
 /* Daily budget banner                                              */
 /* ---------------------------------------------------------------- */
+/* The banner reads as an equation:
+   base rate + active - eaten - target deficit = net
+   Expenditure terms (base rate, active) are purple; the terms subtracted from
+   it (eaten, target deficit) are blue; the net result is green when under
+   budget and red when over. */
 .budget-banner {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 10px;
-    background: #e3f2fd;
-    border: 2px solid #2196F3;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 6px 12px;
+    background: #fafafa;
+    border: 1px solid #ddd;
     border-radius: 8px;
-    padding: 15px 10px;
+    padding: 16px 12px;
     margin: 20px 0;
     text-align: center;
+}
+
+.budget-cell {
+    min-width: 64px;
 }
 
 .budget-value {
     font-size: 26px;
     font-weight: bold;
+    line-height: 1.1;
     color: #0D47A1;
-}
-
-.budget-value.over-budget {
-    color: #c62828;
 }
 
 .budget-label {
     font-size: 13px;
-    color: #1976D2;
     text-transform: uppercase;
     letter-spacing: 0.5px;
+    color: #1976D2;
+}
+
+/* Operators between terms */
+.budget-op {
+    font-size: 24px;
+    font-weight: bold;
+    color: #999;
+}
+
+/* Expenditure group (purple) */
+.group-expend .budget-value {
+    color: #6a1b9a;
+}
+
+.group-expend .budget-label {
+    color: #8e24aa;
+}
+
+/* Intake group (blue) */
+.group-intake .budget-value {
+    color: #1565c0;
+}
+
+.group-intake .budget-label {
+    color: #1976d2;
+}
+
+/* Net result */
+.budget-value.result-pos {
+    color: #2e7d32;
+}
+
+.budget-value.result-neg {
+    color: #c62828;
+}
+
+.budget-label.result-label {
+    color: #555;
 }
 
 .link-button {
     background: none;
     border: none;
-    color: #1976D2;
+    color: inherit;
     cursor: pointer;
     font-size: 16px;
     padding: 0 4px;

--- a/food_tracking/templates/food_tracking/home.html
+++ b/food_tracking/templates/food_tracking/home.html
@@ -4,45 +4,50 @@
 {% block title %}Food Tracker{% endblock %}
 
 {% block extraheaders %}
-<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=13">
-<script src="{% static 'food_tracking/js/tracking.js' %}?v=13"></script>
+<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=14">
+<script src="{% static 'food_tracking/js/tracking.js' %}?v=14"></script>
 {% endblock %}
 
 {% block content %}
 <div style="padding: 20px;">
     <h1>Food Tracking</h1>
 
-    <!-- Daily budget -->
-    <div class="budget-banner">
-        <div class="budget-cell">
-            <div class="budget-value">{{ today_total_calories|floatformat:0 }}</div>
-            <div class="budget-label">net</div>
-        </div>
-        <div class="budget-cell">
-            <div class="budget-value">
-                <span id="active-value">{% if active_is_estimate %}~{% endif %}{{ active_calories }}</span>
-                <button class="link-button" onclick="editActiveCalories()" title="Log active calories">✎</button>
-            </div>
-            <div class="budget-label">active{% if active_is_estimate %} (est.){% endif %}</div>
-        </div>
-        <div class="budget-cell">
+    <!-- Daily budget, read as an equation:
+         base rate + active - eaten - target deficit = net -->
+    <div class="budget-banner equation">
+        <div class="budget-cell group-expend">
             <div class="budget-value">
                 <span id="target-value">{{ base_rate }}</span>
                 <button class="link-button" onclick="editTarget()" title="Edit base rate">✎</button>
             </div>
             <div class="budget-label">base rate</div>
         </div>
-        <div class="budget-cell">
+        <div class="budget-op">+</div>
+        <div class="budget-cell group-expend">
+            <div class="budget-value">
+                <span id="active-value">{% if active_is_estimate %}~{% endif %}{{ active_calories }}</span>
+                <button class="link-button" onclick="editActiveCalories()" title="Log active calories">✎</button>
+            </div>
+            <div class="budget-label">active{% if active_is_estimate %} (est.){% endif %}</div>
+        </div>
+        <div class="budget-op">−</div>
+        <div class="budget-cell group-intake">
+            <div class="budget-value">{{ today_total_calories|floatformat:0 }}</div>
+            <div class="budget-label">eaten</div>
+        </div>
+        <div class="budget-op">−</div>
+        <div class="budget-cell group-intake">
             <div class="budget-value">
                 <span id="deficit-value">{{ goal_deficit }}</span>
                 <button class="link-button" onclick="editGoalDeficit()" title="Edit goal deficit">✎</button>
             </div>
-            <div class="budget-label">goal deficit</div>
+            <div class="budget-label">target deficit</div>
         </div>
+        <div class="budget-op">=</div>
         <div class="budget-cell">
-            <div class="budget-value {% if remaining_calories < 0 %}over-budget{% endif %}"
+            <div class="budget-value {% if remaining_calories < 0 %}result-neg{% else %}result-pos{% endif %}"
                  id="remaining-value">{{ remaining_calories|floatformat:0 }}</div>
-            <div class="budget-label">remaining</div>
+            <div class="budget-label result-label">net</div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary

Reworks the daily budget banner so it reads left-to-right as the equation it actually represents:

```
base rate + active − eaten − target deficit = net
```

This also fixes a confusing label: the old "net" cell was really just *gross intake*, and the final result was labeled "remaining". Now:

- **eaten** = calories logged today (was the misleading "net")
- **net** = the final result (was "remaining"), the only computed result on the right of the `=`

## Colors

- **Purple** — expenditure terms (base rate, active)
- **Blue** — terms subtracted from it (eaten, target deficit)
- **net** — green when under budget, red when over
- Operators in gray; edit pencils inherit their group color

Banner background changed to neutral light gray so the colored figures stand out (blue numbers were invisible on the old blue banner). Wraps cleanly on mobile.

No view/logic changes — the home view already computed all these values. Verified with Playwright screenshots (desktop + mobile) rendered against the real stylesheet. Cache-buster → `v=14`.

## Note

Based on the #148 branch to avoid a cache-buster conflict; merge **#148 first**, then this. GitHub will auto-retarget this to `master` once #148 lands.