### PR TITLE
Collapse the photo picker to a single button

### DIFF
--- a/food_tracking/templates/food_tracking/home.html
+++ b/food_tracking/templates/food_tracking/home.html
@@ -54,16 +54,11 @@
     <!-- AI estimate -->
     <div class="estimate-panel">
         <h2>Quick log</h2>
-        <div class="estimate-actions" style="display: flex; gap: 10px;">
-            <label class="estimate-button" title="Take a photo" aria-label="Take a photo">
+        <div class="estimate-actions">
+            <label class="estimate-button" title="Add a photo" aria-label="Add a photo">
                 📷
-                <input type="file" accept="image/*" capture="environment"
-                       id="photo-input" onchange="estimateFromPhoto(this)" hidden>
-            </label>
-            <label class="estimate-button" title="Choose an existing photo" aria-label="Choose an existing photo">
-                🖼️
                 <input type="file" accept="image/*"
-                       id="photo-library-input" onchange="estimateFromPhoto(this)" hidden>
+                       id="photo-input" onchange="estimateFromPhoto(this)" hidden>
             </label>
         </div>
 


### PR DESCRIPTION
## Why

#151 was squash-merged from an earlier revision — the two-button version (📷 forced-camera + 🖼️ library) landed on master instead of the intended single button. This finishes the change.

## What

One 📷 button with **no** `capture` attribute, so the native picker offers both the camera and the photo library. Removes the separate 🖼️ button and the inline flex styling.

Net effect vs master: drop the second button + `capture="environment"`. HTML-only, no JS/CSS change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)