### PR TITLE
Stack the budget equation by group on mobile

### DIFF
--- a/food_tracking/static/food_tracking/css/styles.css
+++ b/food_tracking/static/food_tracking/css/styles.css
@@ -272,6 +272,21 @@
     color: #999;
 }
 
+/* Forced line breaks: on a phone, split the equation into its natural groups —
+   expenditure (purple) / intake (blue) / net — one per line. No effect on wider
+   screens, where the whole equation fits on one line. */
+.budget-break {
+    display: none;
+}
+
+@media (max-width: 600px) {
+    .budget-break {
+        display: block;
+        flex-basis: 100%;
+        height: 0;
+    }
+}
+
 /* Expenditure group (purple) */
 .group-expend .budget-value {
     color: #6a1b9a;

--- a/food_tracking/templates/food_tracking/home.html
+++ b/food_tracking/templates/food_tracking/home.html
@@ -4,8 +4,8 @@
 {% block title %}Food Tracker{% endblock %}
 
 {% block extraheaders %}
-<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=14">
-<script src="{% static 'food_tracking/js/tracking.js' %}?v=14"></script>
+<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=15">
+<script src="{% static 'food_tracking/js/tracking.js' %}?v=15"></script>
 {% endblock %}
 
 {% block content %}
@@ -30,6 +30,7 @@
             </div>
             <div class="budget-label">active{% if active_is_estimate %} (est.){% endif %}</div>
         </div>
+        <div class="budget-break"></div>
         <div class="budget-op">−</div>
         <div class="budget-cell group-intake">
             <div class="budget-value">{{ today_total_calories|floatformat:0 }}</div>
@@ -43,6 +44,7 @@
             </div>
             <div class="budget-label">target deficit</div>
         </div>
+        <div class="budget-break"></div>
         <div class="budget-op">=</div>
         <div class="budget-cell">
             <div class="budget-value {% if remaining_calories < 0 %}result-neg{% else %}result-pos{% endif %}"


### PR DESCRIPTION
## Why

The mobile row-splitting for the equation banner was written for #150 but never reached master — #150 squash-merged an earlier head, so only the single-line banner landed. This re-lands the grouping.

## What

On screens ≤600px the equation breaks into its natural groups, one line each:

```
base rate  +  active            (purple)
−  eaten  −  target deficit      (blue)
=  net                           (red / green)
```

Done with zero-height `.budget-break` flex items that only take effect under the 600px breakpoint — no effect on desktop, where it stays a single line. Verified at 390px and 1000px with Playwright. Cache-buster → `v=15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)