### PR TITLE
Estimate all foods in a multi-item meal, not just the first

### DIFF
--- a/food_tracking/estimation.py
+++ b/food_tracking/estimation.py
@@ -17,7 +17,9 @@ from anthropic import Anthropic
 # Defaults to the current Sonnet generation; override (e.g. to bump to a newer
 # model) via the FOOD_ESTIMATION_MODEL environment variable, no code change.
 ESTIMATION_MODEL = os.environ.get("FOOD_ESTIMATION_MODEL", "claude-sonnet-4-6")
-MAX_TOKENS = 1024
+# Thinking tokens count against max_tokens, so leave room for the model to
+# reason through multi-item meals before it calls the tool.
+MAX_TOKENS = 4096
 ESTIMATE_TOOL_NAME = "record_estimate"
 
 SUPPORTED_IMAGE_MEDIA_TYPES = frozenset(
@@ -26,11 +28,14 @@ SUPPORTED_IMAGE_MEDIA_TYPES = frozenset(
 
 SYSTEM_PROMPT = (
     "You are a nutrition assistant that estimates the calorie content of food. "
-    "Estimate the total calories for the food described, accounting for typical "
-    "portion sizes and preparation. Be realistic, not conservative. Always call "
-    "the record_estimate tool with your best single-number estimate. If the "
-    "portion is ambiguous, assume a typical serving and reflect the uncertainty "
-    "in the confidence field."
+    "The user may describe a single food or a whole meal with several distinct "
+    "foods. Include EVERY food mentioned as its own entry in the items list, "
+    "estimate each one's calories accounting for typical portion sizes and "
+    "preparation, and set total_calories to the sum of all items. Be realistic, "
+    "not conservative. Think through the items first if that helps, then always "
+    "finish by calling the record_estimate tool with your best single-number "
+    "estimate. If a portion is ambiguous, assume a typical serving and reflect "
+    "the uncertainty in the confidence field."
 )
 
 ESTIMATE_TOOL: dict[str, Any] = {
@@ -117,14 +122,20 @@ def _parse_estimate(data: Any) -> EstimateResult:
 
 
 def _run_estimate(content: list[dict[str, Any]]) -> EstimateResult:
-    """Send a user content payload to Claude and parse the forced tool call."""
+    """Send a user content payload to Claude and parse the tool call.
+
+    Adaptive thinking lets the model enumerate each food in a multi-item meal
+    before committing to numbers; thinking is incompatible with a forced tool
+    choice, so the system prompt (not tool_choice) ensures the tool gets called.
+    """
     client = _get_client()
     response = client.messages.create(
         model=ESTIMATION_MODEL,
         max_tokens=MAX_TOKENS,
         system=SYSTEM_PROMPT,
+        thinking={"type": "adaptive"},
         tools=[ESTIMATE_TOOL],
-        tool_choice={"type": "tool", "name": ESTIMATE_TOOL_NAME},
+        tool_choice={"type": "auto"},
         messages=[{"role": "user", "content": content}],
     )
 
@@ -146,7 +157,7 @@ def estimate_from_image(
         raise ValueError(f"Unsupported image type: {media_type}")
 
     encoded = base64.standard_b64encode(image_bytes).decode("utf-8")
-    prompt = "Estimate the calories in this food."
+    prompt = "Estimate the total calories in all the food shown in this photo."
     if note:
         prompt = f"{prompt} Additional context from the user: {note}"
 
@@ -166,7 +177,10 @@ def estimate_from_image(
 
 def estimate_from_text(text: str) -> EstimateResult:
     """Estimate calories from a free-text food description."""
-    prompt = f"Estimate the calories in this food: {text}"
+    prompt = (
+        "Estimate the total calories in everything the user ate, covering "
+        f"every food mentioned: {text}"
+    )
     return _run_estimate([{"type": "text", "text": prompt}])
 
 

--- a/food_tracking/test_estimation.py
+++ b/food_tracking/test_estimation.py
@@ -73,7 +73,9 @@ class RunEstimateTests(TestCase):
             estimation.estimate_from_text("mystery food")
 
     @patch("food_tracking.estimation._get_client")
-    def test_estimate_from_text_sends_forced_tool(self, mock_get_client):
+    def test_estimate_from_text_enables_thinking_with_auto_tool_choice(
+        self, mock_get_client
+    ):
         client = Mock()
         client.messages.create.return_value = _make_tool_use_response()
         mock_get_client.return_value = client
@@ -82,10 +84,31 @@ class RunEstimateTests(TestCase):
 
         _, kwargs = client.messages.create.call_args
         self.assertEqual(kwargs["model"], estimation.ESTIMATION_MODEL)
-        self.assertEqual(
-            kwargs["tool_choice"],
-            {"type": "tool", "name": estimation.ESTIMATE_TOOL_NAME},
+        # Thinking is incompatible with a forced tool choice, so the call must
+        # use adaptive thinking + auto tool choice together.
+        self.assertEqual(kwargs["thinking"], {"type": "adaptive"})
+        self.assertEqual(kwargs["tool_choice"], {"type": "auto"})
+
+    @patch("food_tracking.estimation._get_client")
+    def test_run_estimate_skips_non_tool_blocks(self, mock_get_client):
+        # With auto tool choice the model may emit thinking/text blocks before
+        # the tool call; parsing must find the tool_use block among them.
+        thinking_block = Mock()
+        thinking_block.type = "thinking"
+        text_block = Mock()
+        text_block.type = "text"
+        tool_response = _make_tool_use_response(
+            description="Plantains, beans, rice, and pizza", total_calories=1250
         )
+        tool_response.content = [thinking_block, text_block] + tool_response.content
+
+        client = Mock()
+        client.messages.create.return_value = tool_response
+        mock_get_client.return_value = client
+
+        result = estimation.estimate_from_text("plantains, beans, rice, pizza")
+
+        self.assertEqual(result.calories, 1250)
 
 
 class EstimateFromImageTests(TestCase):


### PR DESCRIPTION
## Problem

Submitting several foods at once ("I ate plantains, beans, rice, pizza") sometimes returned calories for only the first food.

## Cause

The prompts framed the task as a single food ("Estimate the calories in this food: ..."), and `tool_choice` forced the `record_estimate` tool, so the model jumped straight into filling the schema with no room to enumerate the items — sometimes latching onto just the first one.

## Fix

- Reword the system, free-text, and photo prompts to explicitly cover every food mentioned, with each food as its own `items` entry and `total_calories` as the sum
- Enable adaptive thinking so the model can reason through the meal before answering; switch `tool_choice` to `auto` (thinking is incompatible with a forced tool call — the system prompt now instructs the model to always finish with the tool call, and the existing no-tool-call error path remains as a safety net)
- Raise `MAX_TOKENS` 1024 → 4096 since thinking tokens count against the limit

## Testing

- All 118 `food_tracking` tests pass; updated the forced-tool-choice test and added one covering thinking/text blocks preceding the tool call
- Live smoke test with the exact failing input now returns all four foods itemized (plantains 220 + beans 220 + rice 200 + pizza 550 = 1190 cal)

Note: each estimate now uses somewhat more output tokens and may take a second or two longer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6NgmyBo3ZxUe92pVUfmh6