### PR TITLE
Allow viewing and logging against past days

### DIFF
--- a/food_tracking/static/food_tracking/css/styles.css
+++ b/food_tracking/static/food_tracking/css/styles.css
@@ -228,6 +228,55 @@
 /* ---------------------------------------------------------------- */
 /* Daily budget banner                                              */
 /* ---------------------------------------------------------------- */
+/* Day navigation: step back to view/fill in a past day               */
+/* ---------------------------------------------------------------- */
+.day-nav {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 10px 0;
+}
+
+.day-nav-arrow {
+    font-size: 22px;
+    font-weight: bold;
+    color: #1976D2;
+    text-decoration: none;
+    padding: 2px 10px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    background: #fafafa;
+}
+
+.day-nav-arrow.disabled {
+    color: #ccc;
+    pointer-events: none;
+}
+
+.day-nav-label {
+    font-size: 18px;
+    font-weight: bold;
+    color: #333;
+    min-width: 90px;
+    text-align: center;
+}
+
+.day-nav-today {
+    font-size: 14px;
+    color: #1976D2;
+}
+
+/* Make it hard to log to the wrong day by accident */
+.past-day-banner {
+    background: #fff8e1;
+    border: 1px solid #ffe082;
+    border-radius: 8px;
+    color: #8d6e00;
+    padding: 10px 14px;
+    margin: 10px 0;
+}
+
+/* ---------------------------------------------------------------- */
 /* The banner reads as an equation:
    base rate + active - eaten - target deficit = net
    Expenditure terms (base rate, active) are purple; the terms subtracted from

--- a/food_tracking/static/food_tracking/js/tracking.js
+++ b/food_tracking/static/food_tracking/js/tracking.js
@@ -7,6 +7,18 @@
  * @param {string} name - Cookie name
  * @returns {string|null} - Cookie value or null
  */
+/**
+ * Append the page's viewed day (set by the home template as VIEW_DATE) to a
+ * write payload, so entries land on the day being viewed rather than today.
+ * No-op on pages that don't set VIEW_DATE (e.g. reports).
+ * @param {FormData} formData
+ */
+function appendViewDate(formData) {
+    if (typeof VIEW_DATE !== 'undefined' && VIEW_DATE) {
+        formData.append('date', VIEW_DATE);
+    }
+}
+
 function getCookie(name) {
     let cookieValue = null;
     if (document.cookie && document.cookie !== '') {
@@ -81,6 +93,7 @@ function logFood(foodId, quantity = 1.0) {
     const formData = new FormData();
     formData.append('food_id', foodId);
     formData.append('quantity', quantity.toString());
+    appendViewDate(formData);
 
     // Send AJAX request
     fetch('/food/log/', {
@@ -345,6 +358,7 @@ function confirmEstimate() {
     const formData = new FormData();
     formData.append('description', description);
     formData.append('calories', calories);
+    appendViewDate(formData);
 
     postForm('/food/log-estimate/', formData)
         .then(data => {
@@ -412,7 +426,7 @@ function editGoalDeficit() {
 }
 
 /**
- * Prompt for and save today's Apple Watch active (Move ring) calories.
+ * Prompt for and save the viewed day's Apple Watch active (Move ring) calories.
  */
 function editActiveCalories() {
     const current = document.getElementById('active-value').textContent.trim().replace('~', '');
@@ -422,6 +436,7 @@ function editActiveCalories() {
     }
     const formData = new FormData();
     formData.append('active_calories', value);
+    appendViewDate(formData);
 
     postForm('/food/active/', formData)
         .then(data => {

--- a/food_tracking/templates/food_tracking/home.html
+++ b/food_tracking/templates/food_tracking/home.html
@@ -4,13 +4,36 @@
 {% block title %}Food Tracker{% endblock %}
 
 {% block extraheaders %}
-<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=15">
-<script src="{% static 'food_tracking/js/tracking.js' %}?v=15"></script>
+<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=16">
+<script src="{% static 'food_tracking/js/tracking.js' %}?v=16"></script>
 {% endblock %}
 
 {% block content %}
+<script>
+    // The Pacific day this page is showing; sent with every write so entries
+    // land on the day being viewed, not the current day.
+    const VIEW_DATE = "{{ view_date|date:'Y-m-d' }}";
+</script>
 <div style="padding: 20px;">
     <h1>Food Tracking</h1>
+
+    <!-- Day navigation: step back to fill in a forgotten day -->
+    <div class="day-nav">
+        <a class="day-nav-arrow" href="?date={{ prev_date }}" title="Previous day">←</a>
+        <span class="day-nav-label">{% if is_today %}Today{% else %}{{ view_date|date:"D, N j" }}{% endif %}</span>
+        {% if is_today %}
+        <span class="day-nav-arrow disabled">→</span>
+        {% else %}
+        <a class="day-nav-arrow" href="?date={{ next_date }}" title="Next day">→</a>
+        <a class="day-nav-today" href="{% url 'food_tracking:home' %}">Today</a>
+        {% endif %}
+    </div>
+
+    {% if not is_today %}
+    <div class="past-day-banner">
+        Viewing a past day — anything you log here lands on {{ view_date|date:"l, N j" }}.
+    </div>
+    {% endif %}
 
     <!-- Daily budget, read as an equation:
          base rate + active - eaten - target deficit = net -->
@@ -125,7 +148,7 @@
         {% endfor %}
     </div>
 
-    <h2 style="margin-top: 40px;">Today's Consumption</h2>
+    <h2 style="margin-top: 40px;">{% if is_today %}Today's{% else %}{{ view_date|date:"D, N j" }}{% endif %} Consumption</h2>
     {% if today_consumption %}
     <table class="checkered-blue consumption-table">
         <thead>
@@ -150,7 +173,7 @@
         </tbody>
     </table>
     {% else %}
-    <p>No consumption logged today. Start tracking above!</p>
+    <p>No consumption logged {% if is_today %}today. Start tracking above!{% else %}on this day.{% endif %}</p>
     {% endif %}
 </div>
 {% endblock %}

--- a/food_tracking/test_views.py
+++ b/food_tracking/test_views.py
@@ -17,6 +17,7 @@ from food_tracking.views import (
     calculate_totals_by_period,
     get_active_calories_for_date,
     get_active_foods,
+    get_pacific_day_bounds,
 )
 
 
@@ -947,3 +948,213 @@ class SetActiveCaloriesViewTests(TestCase):
         self.assertEqual(response.context["active_calories"], 500)
         self.assertTrue(response.context["active_is_estimate"])
         self.assertEqual(response.context["effective_budget"], 1800)
+
+
+class PastDayViewTests(TestCase):
+    """Tests for viewing and logging against a past day via ?date= / POST date."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username="pastday", password="testpass")
+        cls.food = Food.objects.create(
+            name="Past Day Food",
+            icon="🍕",
+            serving_size="1 slice",
+            calories_per_serving=Decimal("285.00"),
+            active=True,
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.login(username="pastday", password="testpass")
+
+    # -- home view -------------------------------------------------------
+
+    @freeze_time("2024-01-15 20:00:00")  # noon Pacific on Jan 15
+    def test_home_with_past_date_shows_that_days_consumption(self):
+        # Noon Pacific on Jan 14 is 20:00 UTC
+        Consumption.objects.create(
+            user=self.user,
+            food=self.food,
+            quantity=Decimal("1.0"),
+            consumed_at=timezone.now() - timedelta(days=1),
+        )
+        Consumption.objects.create(
+            user=self.user, food=self.food, quantity=Decimal("2.0")
+        )
+
+        response = self.client.get(
+            reverse("food_tracking:home"), {"date": "2024-01-14"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["today_consumption"]), 1)
+        self.assertEqual(
+            response.context["today_consumption"][0].quantity, Decimal("1.0")
+        )
+        self.assertFalse(response.context["is_today"])
+        self.assertEqual(response.context["view_date"], date(2024, 1, 14))
+        self.assertEqual(response.context["prev_date"], "2024-01-13")
+        self.assertEqual(response.context["next_date"], "2024-01-15")
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_home_default_is_today(self):
+        response = self.client.get(reverse("food_tracking:home"))
+        self.assertTrue(response.context["is_today"])
+        self.assertEqual(response.context["view_date"], date(2024, 1, 15))
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_home_future_date_falls_back_to_today(self):
+        response = self.client.get(
+            reverse("food_tracking:home"), {"date": "2024-01-16"}
+        )
+        self.assertTrue(response.context["is_today"])
+        self.assertEqual(response.context["view_date"], date(2024, 1, 15))
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_home_malformed_date_falls_back_to_today(self):
+        response = self.client.get(
+            reverse("food_tracking:home"), {"date": "not-a-date"}
+        )
+        self.assertTrue(response.context["is_today"])
+        self.assertEqual(response.context["view_date"], date(2024, 1, 15))
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_home_past_day_shows_banner(self):
+        response = self.client.get(
+            reverse("food_tracking:home"), {"date": "2024-01-14"}
+        )
+        self.assertContains(response, "Viewing a past day")
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_home_past_day_uses_that_days_active_calories(self):
+        DailyActiveCalories.objects.create(
+            user=self.user, date=date(2024, 1, 14), active_calories=650
+        )
+        response = self.client.get(
+            reverse("food_tracking:home"), {"date": "2024-01-14"}
+        )
+        self.assertEqual(response.context["active_calories"], 650)
+        self.assertFalse(response.context["active_is_estimate"])
+
+    # -- log_consumption -------------------------------------------------
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_log_consumption_backdates_to_noon_pacific(self):
+        response = self.client.post(
+            reverse("food_tracking:log_consumption"),
+            {"food_id": self.food.id, "quantity": "1.0", "date": "2024-01-10"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        consumption = Consumption.objects.get(user=self.user)
+        consumed_pacific = consumption.consumed_at.astimezone(
+            timezone.get_fixed_timezone(-480)  # PST (UTC-8) in January
+        )
+        self.assertEqual(consumed_pacific.date(), date(2024, 1, 10))
+        self.assertEqual(consumed_pacific.hour, 12)
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_log_consumption_today_date_uses_current_time(self):
+        response = self.client.post(
+            reverse("food_tracking:log_consumption"),
+            {"food_id": self.food.id, "quantity": "1.0", "date": "2024-01-15"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        consumption = Consumption.objects.get(user=self.user)
+        self.assertEqual(consumption.consumed_at, timezone.now())
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_log_consumption_rejects_future_date(self):
+        response = self.client.post(
+            reverse("food_tracking:log_consumption"),
+            {"food_id": self.food.id, "date": "2024-01-16"},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid date", response.json()["error"])
+        self.assertEqual(Consumption.objects.count(), 0)
+
+    def test_log_consumption_rejects_malformed_date(self):
+        response = self.client.post(
+            reverse("food_tracking:log_consumption"),
+            {"food_id": self.food.id, "date": "yesterday"},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(Consumption.objects.count(), 0)
+
+    # -- log_estimate ------------------------------------------------------
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_log_estimate_backdates_to_noon_pacific(self):
+        response = self.client.post(
+            reverse("food_tracking:log_estimate"),
+            {"description": "Forgotten pizza", "calories": "600", "date": "2024-01-14"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        consumption = Consumption.objects.get(user=self.user)
+        consumed_pacific = consumption.consumed_at.astimezone(
+            timezone.get_fixed_timezone(-480)
+        )
+        self.assertEqual(consumed_pacific.date(), date(2024, 1, 14))
+        self.assertEqual(consumed_pacific.hour, 12)
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_log_estimate_rejects_future_date(self):
+        response = self.client.post(
+            reverse("food_tracking:log_estimate"),
+            {
+                "description": "Time-travel snack",
+                "calories": "100",
+                "date": "2024-02-01",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(Consumption.objects.count(), 0)
+
+    # -- set_active_calories ----------------------------------------------
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_set_active_calories_for_past_day(self):
+        response = self.client.post(
+            reverse("food_tracking:set_active_calories"),
+            {"active_calories": "700", "date": "2024-01-14"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        entry = DailyActiveCalories.objects.get(user=self.user)
+        self.assertEqual(entry.date, date(2024, 1, 14))
+        self.assertEqual(entry.active_calories, 700)
+        # Today has no entry
+        self.assertFalse(
+            DailyActiveCalories.objects.filter(
+                user=self.user, date=date(2024, 1, 15)
+            ).exists()
+        )
+
+    @freeze_time("2024-01-15 20:00:00")
+    def test_set_active_calories_rejects_future_date(self):
+        response = self.client.post(
+            reverse("food_tracking:set_active_calories"),
+            {"active_calories": "700", "date": "2024-01-16"},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(DailyActiveCalories.objects.count(), 0)
+
+
+class DayBoundsTests(TestCase):
+    """Tests for Pacific day boundary computation, including DST days."""
+
+    def test_normal_day_is_24_hours(self):
+        start, end = get_pacific_day_bounds(date(2024, 1, 15))
+        self.assertEqual(end - start, timedelta(hours=24))
+
+    def test_spring_forward_day_is_23_hours(self):
+        # 2024-03-10: Pacific clocks jump 2am -> 3am
+        start, end = get_pacific_day_bounds(date(2024, 3, 10))
+        self.assertEqual(end - start, timedelta(hours=23))
+
+    def test_fall_back_day_is_25_hours(self):
+        # 2024-11-03: Pacific clocks fall back 2am -> 1am
+        start, end = get_pacific_day_bounds(date(2024, 11, 3))
+        self.assertEqual(end - start, timedelta(hours=25))

--- a/food_tracking/views.py
+++ b/food_tracking/views.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import date as date_cls
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 from decimal import Decimal, InvalidOperation
 
 import pytz
@@ -25,12 +25,57 @@ from food_tracking.models import CalorieTarget, Consumption, DailyActiveCalories
 # Use Pacific timezone for all date calculations
 PACIFIC_TZ = pytz.timezone("America/Los_Angeles")
 
+# Backdated entries (logged against a past day) get this hour, Pacific time.
+# Noon sits safely inside the day regardless of DST or UTC conversion, unlike
+# midnight which lands exactly on the day boundary.
+BACKDATE_HOUR = 12
+
+DATE_PARAM_FORMAT = "%Y-%m-%d"
+
 
 def get_pacific_today_start() -> datetime:
     """Get the start of today (midnight) in Pacific timezone."""
     now_pacific = timezone.now().astimezone(PACIFIC_TZ)
     today_start_pacific = now_pacific.replace(hour=0, minute=0, second=0, microsecond=0)
     return today_start_pacific
+
+
+def get_pacific_day_bounds(day: date_cls) -> tuple[datetime, datetime]:
+    """Return the [start, end) datetimes of a Pacific calendar day.
+
+    Both bounds are localized midnights rather than start + 24h, so days that
+    contain a DST transition (23 or 25 hours long) keep correct boundaries.
+    """
+    start = PACIFIC_TZ.localize(datetime.combine(day, time.min))
+    end = PACIFIC_TZ.localize(datetime.combine(day + timedelta(days=1), time.min))
+    return start, end
+
+
+def get_requested_day(request: HttpRequest) -> date_cls:
+    """Return the Pacific day a write request applies to (default: today).
+
+    Raises ValueError for malformed dates or dates in the future, so callers
+    can turn either into a 400.
+    """
+    raw = request.POST.get("date", "").strip()
+    today = get_pacific_today_start().date()
+    if not raw:
+        return today
+    day = datetime.strptime(raw, DATE_PARAM_FORMAT).date()
+    if day > today:
+        raise ValueError("Date cannot be in the future.")
+    return day
+
+
+def resolve_consumed_at(day: date_cls) -> datetime:
+    """Timestamp to store for a consumption logged against `day`.
+
+    Entries for today keep the real time so ordering within the day is
+    preserved; backdated entries get noon Pacific on that day.
+    """
+    if day == get_pacific_today_start().date():
+        return timezone.now()
+    return PACIFIC_TZ.localize(datetime.combine(day, time(hour=BACKDATE_HOUR)))
 
 
 def get_active_foods() -> list[Food]:
@@ -120,20 +165,37 @@ def calculate_totals_by_period(
 
 @login_required
 def home(request: HttpRequest) -> HttpResponse:
-    """Display food tracking grid and today's consumption."""
-    from collections import Counter
+    """Display the food tracking grid and consumption for one Pacific day.
 
+    Defaults to today; ?date=YYYY-MM-DD shows a past day so forgotten entries
+    can be logged retroactively. Malformed or future dates fall back to today
+    rather than erroring, since they only arrive via hand-edited URLs.
+    """
     foods = get_active_foods()
 
-    # Get all consumption from today (Pacific timezone), most recent first
-    today_start = get_pacific_today_start()
+    today = get_pacific_today_start().date()
+    try:
+        view_date = datetime.strptime(
+            request.GET.get("date", ""), DATE_PARAM_FORMAT
+        ).date()
+    except ValueError:
+        view_date = today
+    view_date = min(view_date, today)
+    is_today = view_date == today
+
+    # All consumption for the viewed day (Pacific), most recent first. The
+    # "today_*" names are kept for template compatibility; they mean "the
+    # viewed day" throughout.
+    day_start, day_end = get_pacific_day_bounds(view_date)
     today_consumption = (
-        Consumption.objects.filter(user=request.user, consumed_at__gte=today_start)
+        Consumption.objects.filter(
+            user=request.user, consumed_at__gte=day_start, consumed_at__lt=day_end
+        )
         .select_related("food")
         .order_by("-consumed_at")
     )
 
-    # Calculate today's total quantity per food for badges
+    # Calculate the day's total quantity per food for badges
     today_quantities: dict[int, Decimal] = {}
     for consumption in today_consumption:
         food_id = consumption.food_id
@@ -141,11 +203,11 @@ def home(request: HttpRequest) -> HttpResponse:
             today_quantities.get(food_id, Decimal("0")) + consumption.quantity
         )
 
-    # Add today's total quantity to each food object
+    # Add the day's total quantity to each food object
     for food in foods:
         food.today_count = today_quantities.get(food.id, Decimal("0"))
 
-    # Calculate total calories consumed today (food only)
+    # Calculate total calories consumed on the viewed day (food only)
     today_total_calories = sum(c.total_calories() for c in today_consumption)
 
     target = get_or_create_target(request.user)
@@ -155,7 +217,7 @@ def home(request: HttpRequest) -> HttpResponse:
     # Active calories (Apple Watch Move ring) layered on top of the base rate,
     # less the goal deficit the user is aiming for.
     active_calories, active_is_estimate = get_active_calories_for_date(
-        request.user, today_start.date()
+        request.user, view_date
     )
     effective_budget = base_rate + active_calories - goal_deficit
     remaining_calories = effective_budget - today_total_calories
@@ -170,6 +232,10 @@ def home(request: HttpRequest) -> HttpResponse:
         "goal_deficit": goal_deficit,
         "effective_budget": effective_budget,
         "remaining_calories": remaining_calories,
+        "view_date": view_date,
+        "is_today": is_today,
+        "prev_date": (view_date - timedelta(days=1)).isoformat(),
+        "next_date": (view_date + timedelta(days=1)).isoformat(),
     }
     return render(request, "food_tracking/home.html", context)
 
@@ -218,11 +284,17 @@ def log_consumption(request: HttpRequest) -> JsonResponse:
                 {"success": False, "error": "Missing food_id"}, status=400
             )
 
+        try:
+            day = get_requested_day(request)
+        except ValueError:
+            return JsonResponse({"success": False, "error": "Invalid date"}, status=400)
+
         food = Food.objects.get(id=food_id)
         consumption = Consumption.objects.create(
             user=request.user,
             food=food,
             quantity=Decimal(quantity),
+            consumed_at=resolve_consumed_at(day),
         )
 
         return JsonResponse(
@@ -356,12 +428,18 @@ def log_estimate(request: HttpRequest) -> JsonResponse:
                 status=400,
             )
 
+        try:
+            day = get_requested_day(request)
+        except ValueError:
+            return JsonResponse({"success": False, "error": "Invalid date"}, status=400)
+
         consumption = Consumption.objects.create(
             user=request.user,
             food=None,
             description=description,
             calories=calories,
             notes=request.POST.get("notes", ""),
+            consumed_at=resolve_consumed_at(day),
         )
         return JsonResponse(
             {"success": True, "consumption": consumption.to_dict_for_api()}
@@ -428,10 +506,11 @@ def set_goal_deficit(request: HttpRequest) -> JsonResponse:
 @login_required
 @require_http_methods(["POST"])
 def set_active_calories(request: HttpRequest) -> JsonResponse:
-    """Set today's Apple Watch active (Move ring) calories.
+    """Set a day's Apple Watch active (Move ring) calories.
 
-    Upserts a single DailyActiveCalories row for the current Pacific day so the
-    user can log it once at the end of the day (and correct it if needed).
+    Upserts a single DailyActiveCalories row for the requested Pacific day
+    (default: today) so the user can log it once at the end of the day, correct
+    it later, or fill in a day they forgot.
     """
     try:
         active_raw = request.POST.get("active_calories", "")
@@ -448,10 +527,14 @@ def set_active_calories(request: HttpRequest) -> JsonResponse:
                 status=400,
             )
 
-        today = get_pacific_today_start().date()
+        try:
+            day = get_requested_day(request)
+        except ValueError:
+            return JsonResponse({"success": False, "error": "Invalid date"}, status=400)
+
         entry, _ = DailyActiveCalories.objects.update_or_create(
             user=request.user,
-            date=today,
+            date=day,
             defaults={"active_calories": active_calories},
         )
         return JsonResponse({"success": True, "active": entry.to_dict_for_api()})


### PR DESCRIPTION
## Feature

You can now step back to a previous day and fill in anything you forgot to log. The home view takes `?date=YYYY-MM-DD` and renders the same page for that Pacific day: its budget equation, its food-grid badges, and its consumption table. A ←/→ day navigator sits under the title, with a "Today" shortcut and a yellow banner making it obvious you're on a past day.

## The tricky details

- **What timestamp does a backdated entry get?** Noon Pacific on the viewed day. Noon sits safely inside the day after UTC conversion regardless of DST, unlike midnight which lands exactly on the boundary. Entries logged for *today* keep `now()` so ordering within the day is preserved.
- **Which writes are date-aware?** Quick-log (food grid), AI-estimate logging, and active calories all send the viewed date (via a `VIEW_DATE` global the template sets). Base rate and target deficit stay global — they're settings, not per-day data.
- **DST-correct day windows.** Day bounds are computed as localized midnights on both sides rather than `start + 24h`, so 23- and 25-hour transition days filter correctly. Consumption filtering also gained an upper bound (`< day end`), which the old `>= today_start` query didn't need.
- **Stale tabs.** The page sends its own viewed date with every write, so a tab left open past midnight logs to the day you're looking at, not the new server day.
- **Validation.** Future/malformed dates fall back to today on the GET view (they only arrive via hand-edited URLs) and return 400 on writes.
- **Budget math on past days.** `active calories` come from that day's logged entry (or the usual estimate), so a past day shows its true net.

## Testing

- 17 new tests: past-day filtering, banner rendering, noon-Pacific backdating for both consumption endpoints, per-day active calories upsert, future/malformed date rejection, and 23/24/25-hour day-bound checks across DST transitions
- Full food_tracking suite: 135 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6NgmyBo3ZxUe92pVUfmh6