### PR TITLE
Cap estimation thinking effort; default recipe portion to 0.5

### DIFF
--- a/food_tracking/estimation.py
+++ b/food_tracking/estimation.py
@@ -20,6 +20,10 @@ ESTIMATION_MODEL = os.environ.get("FOOD_ESTIMATION_MODEL", "claude-sonnet-4-6")
 # Thinking tokens count against max_tokens, so leave room for the model to
 # reason through multi-item meals before it calls the tool.
 MAX_TOKENS = 4096
+# Caps how deeply the model thinks. "low" keeps enough reasoning to enumerate a
+# multi-item meal but avoids the long thinking runs that made recipe estimates
+# blow past the web server's request timeout (surfacing as 500s).
+ESTIMATION_EFFORT = os.environ.get("FOOD_ESTIMATION_EFFORT", "low")
 ESTIMATE_TOOL_NAME = "record_estimate"
 
 SUPPORTED_IMAGE_MEDIA_TYPES = frozenset(
@@ -134,6 +138,7 @@ def _run_estimate(content: list[dict[str, Any]]) -> EstimateResult:
         max_tokens=MAX_TOKENS,
         system=SYSTEM_PROMPT,
         thinking={"type": "adaptive"},
+        output_config={"effort": ESTIMATION_EFFORT},
         tools=[ESTIMATE_TOOL],
         tool_choice={"type": "auto"},
         messages=[{"role": "user", "content": content}],

--- a/food_tracking/templates/food_tracking/home.html
+++ b/food_tracking/templates/food_tracking/home.html
@@ -99,7 +99,7 @@
                       placeholder="Paste the full recipe text."></textarea>
             <div class="recipe-row">
                 <label>Fraction you ate:
-                    <input type="number" id="fraction-input" min="0.01" max="1" step="0.05" value="0.25">
+                    <input type="number" id="fraction-input" min="0.01" max="1" step="0.05" value="0.5">
                 </label>
                 <button class="estimate-button" onclick="estimateFromRecipe()">Estimate</button>
             </div>

--- a/food_tracking/test_estimation.py
+++ b/food_tracking/test_estimation.py
@@ -88,6 +88,11 @@ class RunEstimateTests(TestCase):
         # use adaptive thinking + auto tool choice together.
         self.assertEqual(kwargs["thinking"], {"type": "adaptive"})
         self.assertEqual(kwargs["tool_choice"], {"type": "auto"})
+        # Effort is capped so recipe estimates don't think past the web
+        # server's request timeout.
+        self.assertEqual(
+            kwargs["output_config"], {"effort": estimation.ESTIMATION_EFFORT}
+        )
 
     @patch("food_tracking.estimation._get_client")
     def test_run_estimate_skips_non_tool_blocks(self, mock_get_client):


### PR DESCRIPTION
## Problem

Since enabling adaptive thinking, recipe estimates sometimes think long enough to blow past the web server's request timeout (surfacing as 500s), and the delay is noticeable even when they succeed.

## Fix

- Cap thinking depth with `output_config: {effort: "low"}`. Low effort still enumerates every ingredient — it just stops the model from deliberating at length first. Overridable via `FOOD_ESTIMATION_EFFORT` (no code change) if we ever want to trade latency for depth: Sonnet 4.6 accepts `low` / `medium` / `high` / `max`.
- Default the recipe fraction input to `0.5` instead of `0.25`.

## Testing

- Full food_tracking suite passes (135 tests); request-shape test now asserts the effort cap
- Live check: a full lasagna recipe at 50% returned in ~10s with a complete 8-ingredient breakdown (1710 cal, all ingredients halved correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6NgmyBo3ZxUe92pVUfmh6