### PR TITLE
Raise estimation max_tokens to 8192 for thinking headroom

### DIFF
--- a/food_tracking/estimation.py
+++ b/food_tracking/estimation.py
@@ -18,8 +18,11 @@ from anthropic import Anthropic
 # model) via the FOOD_ESTIMATION_MODEL environment variable, no code change.
 ESTIMATION_MODEL = os.environ.get("FOOD_ESTIMATION_MODEL", "claude-sonnet-4-6")
 # Thinking tokens count against max_tokens, so leave room for the model to
-# reason through multi-item meals before it calls the tool.
-MAX_TOKENS = 4096
+# reason through multi-item meals before it calls the tool. A worst-case
+# multi-dish recipe measured ~1,700 output tokens at low effort; 8192 leaves
+# ample headroom even if FOOD_ESTIMATION_EFFORT is raised later. Unused
+# headroom costs nothing — only generated tokens are billed.
+MAX_TOKENS = 8192
 # Caps how deeply the model thinks. "low" keeps enough reasoning to enumerate a
 # multi-item meal but avoids the long thinking runs that made recipe estimates
 # blow past the web server's request timeout (surfacing as 500s).


### PR DESCRIPTION
## Change

Bump the estimation call's `max_tokens` from 4096 to 8192.

## Why

Thinking tokens count against `max_tokens`. A worst-case measurement (full Thanksgiving dinner recipe, ~10 dishes) used ~1,700 output tokens at low effort, so 4096 had ~2.4× headroom — but if `FOOD_ESTIMATION_EFFORT` is ever raised in production (see #156), thinking grows and eats into that margin. 8192 makes truncation impossible in practice, and unused headroom costs nothing: only generated tokens are billed.

The existing `stop_reason == "max_tokens"` guard stays as the backstop either way.

Complements #156 (effort cap); the two are independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6NgmyBo3ZxUe92pVUfmh6