### PR TITLE
Let the user correct an estimate before logging it

### DIFF
--- a/food_tracking/estimation.py
+++ b/food_tracking/estimation.py
@@ -7,6 +7,7 @@ typed EstimateResult; callers decide whether to persist it as a Consumption.
 """
 
 import base64
+import json
 import os
 from dataclasses import dataclass, field
 from typing import Any
@@ -128,12 +129,57 @@ def _parse_estimate(data: Any) -> EstimateResult:
         raise ValueError("Could not read the calorie estimate from the model.") from exc
 
 
-def _run_estimate(content: list[dict[str, Any]]) -> EstimateResult:
+def _build_messages(
+    content: list[dict[str, Any]],
+    previous_estimate: dict[str, Any] | None,
+    correction: str,
+) -> list[dict[str, Any]]:
+    """Build the conversation for an estimate request.
+
+    A fresh estimate is a single user turn. A refinement replays the original
+    request as a two-shot conversation: the prior estimate is restated as an
+    assistant turn, then the user's correction asks for a revised tool call.
+    """
+    messages: list[dict[str, Any]] = [{"role": "user", "content": content}]
+    if previous_estimate is None:
+        return messages
+
+    messages.append(
+        {
+            "role": "assistant",
+            "content": (
+                "Here is my current calorie estimate as JSON: "
+                f"{json.dumps(previous_estimate)}"
+            ),
+        }
+    )
+    messages.append(
+        {
+            "role": "user",
+            "content": (
+                "That estimate needs adjusting. Correction / additional context "
+                f"from the user: {correction}\n"
+                "Produce an updated estimate: keep the parts of your previous "
+                "estimate that are unaffected, apply the correction, and call "
+                "record_estimate again with the revised numbers."
+            ),
+        }
+    )
+    return messages
+
+
+def _run_estimate(
+    content: list[dict[str, Any]],
+    previous_estimate: dict[str, Any] | None = None,
+    correction: str = "",
+) -> EstimateResult:
     """Send a user content payload to Claude and parse the tool call.
 
     Adaptive thinking lets the model enumerate each food in a multi-item meal
     before committing to numbers; thinking is incompatible with a forced tool
     choice, so the system prompt (not tool_choice) ensures the tool gets called.
+    When previous_estimate/correction are given, the request becomes a
+    refinement conversation (see _build_messages).
     """
     client = _get_client()
     response = client.messages.create(
@@ -144,7 +190,7 @@ def _run_estimate(content: list[dict[str, Any]]) -> EstimateResult:
         output_config={"effort": ESTIMATION_EFFORT},
         tools=[ESTIMATE_TOOL],
         tool_choice={"type": "auto"},
-        messages=[{"role": "user", "content": content}],
+        messages=_build_messages(content, previous_estimate, correction),
     )
 
     if response.stop_reason == "max_tokens":
@@ -158,7 +204,11 @@ def _run_estimate(content: list[dict[str, Any]]) -> EstimateResult:
 
 
 def estimate_from_image(
-    image_bytes: bytes, media_type: str, note: str = ""
+    image_bytes: bytes,
+    media_type: str,
+    note: str = "",
+    previous_estimate: dict[str, Any] | None = None,
+    correction: str = "",
 ) -> EstimateResult:
     """Estimate calories from a food photo, with an optional text note."""
     if media_type not in SUPPORTED_IMAGE_MEDIA_TYPES:
@@ -180,19 +230,30 @@ def estimate_from_image(
         },
         {"type": "text", "text": prompt},
     ]
-    return _run_estimate(content)
+    return _run_estimate(content, previous_estimate, correction)
 
 
-def estimate_from_text(text: str) -> EstimateResult:
+def estimate_from_text(
+    text: str,
+    previous_estimate: dict[str, Any] | None = None,
+    correction: str = "",
+) -> EstimateResult:
     """Estimate calories from a free-text food description."""
     prompt = (
         "Estimate the total calories in everything the user ate, covering "
         f"every food mentioned: {text}"
     )
-    return _run_estimate([{"type": "text", "text": prompt}])
+    return _run_estimate(
+        [{"type": "text", "text": prompt}], previous_estimate, correction
+    )
 
 
-def estimate_recipe(recipe_text: str, fraction: float) -> EstimateResult:
+def estimate_recipe(
+    recipe_text: str,
+    fraction: float,
+    previous_estimate: dict[str, Any] | None = None,
+    correction: str = "",
+) -> EstimateResult:
     """Estimate calories for the portion of a recipe the user actually ate.
 
     `fraction` is the share of the whole recipe consumed (e.g. 0.25 for a
@@ -206,4 +267,6 @@ def estimate_recipe(recipe_text: str, fraction: float) -> EstimateResult:
         "user ate. Report the eaten portion's calories in total_calories.\n\n"
         f"Recipe:\n{recipe_text}"
     )
-    return _run_estimate([{"type": "text", "text": prompt}])
+    return _run_estimate(
+        [{"type": "text", "text": prompt}], previous_estimate, correction
+    )

--- a/food_tracking/static/food_tracking/css/styles.css
+++ b/food_tracking/static/food_tracking/css/styles.css
@@ -507,6 +507,18 @@
     font-size: 15px;
 }
 
+/* Refinement input sits inline with its Update button */
+.estimate-card-row.refine-row {
+    flex-direction: row;
+    gap: 8px;
+    align-items: center;
+}
+
+.estimate-card-row.refine-row input {
+    flex: 1;
+    min-width: 0;
+}
+
 .estimate-breakdown {
     font-size: 14px;
     color: #444;

--- a/food_tracking/static/food_tracking/js/tracking.js
+++ b/food_tracking/static/food_tracking/js/tracking.js
@@ -140,6 +140,15 @@ function logFood(foodId, quantity = 1.0) {
 /* ------------------------------------------------------------------ */
 
 /**
+ * The inputs of the most recent estimate request and the estimate it produced.
+ * Kept so a correction can replay the original request (photo included) as a
+ * two-shot conversation via refineEstimate().
+ * lastEstimateRequest: { kind: 'text'|'image'|'recipe', ... } or null.
+ */
+let lastEstimateRequest = null;
+let lastEstimate = null;
+
+/**
  * POST a FormData payload with CSRF protection. Resolves to parsed JSON on
  * success; otherwise rejects with an Error carrying a specific message (server
  * error text, a 413 "too large" hint, or a network message) so the UI can tell
@@ -230,6 +239,7 @@ function showEstimate(estimate) {
 function handleEstimateResponse(data) {
     setEstimateStatus('');
     if (data.success) {
+        lastEstimate = data.estimate;
         showEstimate(data.estimate);
     } else {
         alert('Error: ' + (data.error || 'Could not estimate.'));
@@ -297,9 +307,11 @@ function estimateFromPhoto(input) {
     setEstimateStatus('Processing photo…');
     resizeImageFile(file)
         .then(blob => {
+            const note = document.getElementById('text-input').value.trim();
+            lastEstimateRequest = { kind: 'image', blob: blob, note: note };
             const formData = new FormData();
             formData.append('image', blob, 'photo.jpg');
-            formData.append('note', document.getElementById('text-input').value.trim());
+            formData.append('note', note);
             setEstimateStatus('Estimating from photo…');
             return postForm('/food/estimate/', formData);
         })
@@ -316,6 +328,7 @@ function estimateFromText() {
         alert('Describe what you ate first.');
         return;
     }
+    lastEstimateRequest = { kind: 'text', text: text };
     const formData = new FormData();
     formData.append('text', text);
 
@@ -335,6 +348,7 @@ function estimateFromRecipe() {
         alert('Paste a recipe first.');
         return;
     }
+    lastEstimateRequest = { kind: 'recipe', recipe: recipe, fraction: fraction };
     const formData = new FormData();
     formData.append('recipe_text', recipe);
     formData.append('fraction', fraction);
@@ -372,10 +386,55 @@ function confirmEstimate() {
 }
 
 /**
+ * Re-run the last estimate with a user correction ("that was two slices",
+ * "there was also ranch dressing"). Replays the original request — photo
+ * included — plus the previous estimate so the model can revise it.
+ */
+function refineEstimate() {
+    const correction = document.getElementById('refine-input').value.trim();
+    if (!correction) {
+        alert('Describe what to correct or add first.');
+        return;
+    }
+    if (!lastEstimateRequest || !lastEstimate) {
+        alert('Nothing to refine yet — run an estimate first.');
+        return;
+    }
+
+    const formData = new FormData();
+    let url = '/food/estimate/';
+    if (lastEstimateRequest.kind === 'image') {
+        formData.append('image', lastEstimateRequest.blob, 'photo.jpg');
+        formData.append('note', lastEstimateRequest.note);
+    } else if (lastEstimateRequest.kind === 'recipe') {
+        url = '/food/estimate-recipe/';
+        formData.append('recipe_text', lastEstimateRequest.recipe);
+        formData.append('fraction', lastEstimateRequest.fraction);
+    } else {
+        formData.append('text', lastEstimateRequest.text);
+    }
+    formData.append('correction', correction);
+    formData.append('previous_estimate', JSON.stringify(lastEstimate));
+
+    setEstimateStatus('Updating estimate…');
+    postForm(url, formData)
+        .then(data => {
+            if (data.success) {
+                document.getElementById('refine-input').value = '';
+            }
+            handleEstimateResponse(data);
+        })
+        .catch(err => setEstimateStatus('Update failed: ' + err.message));
+}
+
+/**
  * Hide the confirm/edit card without saving.
  */
 function cancelEstimate() {
     document.getElementById('estimate-card').style.display = 'none';
+    document.getElementById('refine-input').value = '';
+    lastEstimateRequest = null;
+    lastEstimate = null;
     setEstimateStatus('');
 }
 

--- a/food_tracking/templates/food_tracking/home.html
+++ b/food_tracking/templates/food_tracking/home.html
@@ -4,8 +4,8 @@
 {% block title %}Food Tracker{% endblock %}
 
 {% block extraheaders %}
-<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=16">
-<script src="{% static 'food_tracking/js/tracking.js' %}?v=16"></script>
+<link rel="stylesheet" type="text/css" href="{% static 'food_tracking/css/styles.css' %}?v=17">
+<script src="{% static 'food_tracking/js/tracking.js' %}?v=17"></script>
 {% endblock %}
 
 {% block content %}
@@ -118,6 +118,12 @@
                 <input type="number" id="confirm-calories" min="0" step="1">
             </div>
             <div id="estimate-breakdown" class="estimate-breakdown"></div>
+            <!-- Two-shot refinement: correct the estimate before logging it -->
+            <div class="estimate-card-row refine-row">
+                <input type="text" id="refine-input"
+                       placeholder="Wrong or missing something? Add details…">
+                <button class="estimate-button" onclick="refineEstimate()">Update</button>
+            </div>
             <div class="estimate-card-buttons">
                 <button class="estimate-button confirm" onclick="confirmEstimate()">Log it</button>
                 <button class="estimate-button cancel" onclick="cancelEstimate()">Cancel</button>

--- a/food_tracking/test_estimation.py
+++ b/food_tracking/test_estimation.py
@@ -217,3 +217,81 @@ class MalformedEstimateTests(TestCase):
             {"description": "Apple", "total_calories": 95}
         )
         self.assertEqual(result.confidence, "low")
+
+
+class RefinementTests(TestCase):
+    """Tests for the two-shot refinement conversation."""
+
+    @patch("food_tracking.estimation._get_client")
+    def test_refinement_builds_three_turn_conversation(self, mock_get_client):
+        client = Mock()
+        client.messages.create.return_value = _make_tool_use_response(
+            description="Pizza, 2 slices", total_calories=570
+        )
+        mock_get_client.return_value = client
+
+        previous = {"description": "Pizza", "calories": 285, "items": []}
+        result = estimation.estimate_from_text(
+            "pizza",
+            previous_estimate=previous,
+            correction="it was actually two slices",
+        )
+
+        _, kwargs = client.messages.create.call_args
+        messages = kwargs["messages"]
+        self.assertEqual(len(messages), 3)
+        self.assertEqual(messages[0]["role"], "user")
+        self.assertEqual(messages[1]["role"], "assistant")
+        self.assertIn('"calories": 285', messages[1]["content"])
+        self.assertEqual(messages[2]["role"], "user")
+        self.assertIn("two slices", messages[2]["content"])
+        self.assertEqual(result.calories, 570)
+
+    @patch("food_tracking.estimation._get_client")
+    def test_fresh_estimate_is_single_turn(self, mock_get_client):
+        client = Mock()
+        client.messages.create.return_value = _make_tool_use_response()
+        mock_get_client.return_value = client
+
+        estimation.estimate_from_text("an apple")
+
+        _, kwargs = client.messages.create.call_args
+        self.assertEqual(len(kwargs["messages"]), 1)
+
+    @patch("food_tracking.estimation._get_client")
+    def test_image_refinement_resends_the_image(self, mock_get_client):
+        client = Mock()
+        client.messages.create.return_value = _make_tool_use_response()
+        mock_get_client.return_value = client
+
+        estimation.estimate_from_image(
+            b"fakebytes",
+            "image/jpeg",
+            previous_estimate={"description": "Salad", "calories": 150},
+            correction="there was ranch dressing on it",
+        )
+
+        _, kwargs = client.messages.create.call_args
+        messages = kwargs["messages"]
+        self.assertEqual(len(messages), 3)
+        self.assertEqual(messages[0]["content"][0]["type"], "image")
+        self.assertIn("ranch", messages[2]["content"])
+
+    @patch("food_tracking.estimation._get_client")
+    def test_recipe_refinement_keeps_fraction_context(self, mock_get_client):
+        client = Mock()
+        client.messages.create.return_value = _make_tool_use_response()
+        mock_get_client.return_value = client
+
+        estimation.estimate_recipe(
+            "Big lasagna recipe",
+            0.5,
+            previous_estimate={"description": "Lasagna", "calories": 1700},
+            correction="I used turkey instead of beef",
+        )
+
+        _, kwargs = client.messages.create.call_args
+        messages = kwargs["messages"]
+        self.assertEqual(len(messages), 3)
+        self.assertIn("50%", messages[0]["content"][0]["text"])
+        self.assertIn("turkey", messages[2]["content"])

--- a/food_tracking/test_views.py
+++ b/food_tracking/test_views.py
@@ -521,7 +521,9 @@ class EstimateViewTests(TestCase):
         data = response.json()
         self.assertTrue(data["success"])
         self.assertEqual(data["estimate"]["calories"], 95)
-        mock_estimate.assert_called_once_with("one apple")
+        mock_estimate.assert_called_once_with(
+            "one apple", previous_estimate=None, correction=""
+        )
 
     @patch("food_tracking.views.estimation.estimate_from_image")
     def test_estimate_from_image_success(self, mock_estimate):
@@ -562,7 +564,9 @@ class EstimateViewTests(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["success"])
-        mock_estimate.assert_called_once_with("big recipe", 0.25)
+        mock_estimate.assert_called_once_with(
+            "big recipe", 0.25, previous_estimate=None, correction=""
+        )
 
     def test_estimate_recipe_missing_text_returns_400(self):
         response = self.client.post(
@@ -1158,3 +1162,99 @@ class DayBoundsTests(TestCase):
         # 2024-11-03: Pacific clocks fall back 2am -> 1am
         start, end = get_pacific_day_bounds(date(2024, 11, 3))
         self.assertEqual(end - start, timedelta(hours=25))
+
+
+class EstimateRefinementViewTests(TestCase):
+    """Tests for the correction/previous_estimate fields on estimate views."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username="refiner", password="testpass")
+
+    def setUp(self):
+        self.client = Client()
+        self.client.login(username="refiner", password="testpass")
+
+    @patch("food_tracking.views.estimation.estimate_from_text")
+    def test_estimate_passes_refinement_to_estimation(self, mock_estimate):
+        mock_estimate.return_value = EstimateResult(
+            description="Pizza, 2 slices", calories=570, confidence="medium"
+        )
+        response = self.client.post(
+            reverse("food_tracking:estimate"),
+            {
+                "text": "pizza",
+                "correction": "two slices actually",
+                "previous_estimate": '{"description": "Pizza", "calories": 285}',
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["estimate"]["calories"], 570)
+        mock_estimate.assert_called_once_with(
+            "pizza",
+            previous_estimate={"description": "Pizza", "calories": 285},
+            correction="two slices actually",
+        )
+
+    @patch("food_tracking.views.estimation.estimate_from_text")
+    def test_estimate_without_refinement_passes_none(self, mock_estimate):
+        mock_estimate.return_value = EstimateResult(
+            description="Apple", calories=95, confidence="high"
+        )
+        response = self.client.post(
+            reverse("food_tracking:estimate"), {"text": "an apple"}
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_estimate.assert_called_once_with(
+            "an apple", previous_estimate=None, correction=""
+        )
+
+    def test_correction_without_previous_estimate_returns_400(self):
+        response = self.client.post(
+            reverse("food_tracking:estimate"),
+            {"text": "pizza", "correction": "two slices"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_previous_estimate_without_correction_returns_400(self):
+        response = self.client.post(
+            reverse("food_tracking:estimate"),
+            {"text": "pizza", "previous_estimate": '{"calories": 285}'},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_malformed_previous_estimate_returns_400(self):
+        response = self.client.post(
+            reverse("food_tracking:estimate"),
+            {"text": "pizza", "correction": "more", "previous_estimate": "not json"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_non_object_previous_estimate_returns_400(self):
+        response = self.client.post(
+            reverse("food_tracking:estimate"),
+            {"text": "pizza", "correction": "more", "previous_estimate": "[1, 2]"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    @patch("food_tracking.views.estimation.estimate_recipe")
+    def test_estimate_recipe_passes_refinement(self, mock_estimate):
+        mock_estimate.return_value = EstimateResult(
+            description="Lasagna", calories=1500, confidence="medium"
+        )
+        response = self.client.post(
+            reverse("food_tracking:estimate_recipe"),
+            {
+                "recipe_text": "Big lasagna recipe",
+                "fraction": "0.5",
+                "correction": "turkey instead of beef",
+                "previous_estimate": '{"description": "Lasagna", "calories": 1700}',
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_estimate.assert_called_once_with(
+            "Big lasagna recipe",
+            0.5,
+            previous_estimate={"description": "Lasagna", "calories": 1700},
+            correction="turkey instead of beef",
+        )

--- a/food_tracking/views.py
+++ b/food_tracking/views.py
@@ -1,7 +1,9 @@
+import json
 from collections import defaultdict
 from datetime import date as date_cls
 from datetime import datetime, time, timedelta
 from decimal import Decimal, InvalidOperation
+from typing import Any
 
 import pytz
 from django.contrib.auth.decorators import login_required
@@ -337,10 +339,40 @@ def reports(request: HttpRequest) -> HttpResponse:
     return render(request, "food_tracking/reports.html", context)
 
 
+def get_refinement_params(request: HttpRequest) -> tuple[dict[str, Any] | None, str]:
+    """Extract optional refinement fields from an estimate request.
+
+    Returns (previous_estimate, correction). Both must be present together —
+    a correction without the prior estimate (or vice versa) raises ValueError,
+    as does a previous_estimate that isn't a JSON object.
+    """
+    correction = request.POST.get("correction", "").strip()
+    previous_raw = request.POST.get("previous_estimate", "").strip()
+
+    if not correction and not previous_raw:
+        return None, ""
+    if not correction or not previous_raw:
+        raise ValueError(
+            "A refinement needs both a correction and the previous estimate."
+        )
+
+    try:
+        previous_estimate = json.loads(previous_raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid previous estimate.") from exc
+    if not isinstance(previous_estimate, dict):
+        raise ValueError("Invalid previous estimate.")
+    return previous_estimate, correction
+
+
 @login_required
 @require_http_methods(["POST"])
 def estimate(request: HttpRequest) -> JsonResponse:
     """Estimate calories from an uploaded photo or a text description.
+
+    Optional correction + previous_estimate fields turn the request into a
+    refinement: the original input is resent along with the prior estimate and
+    the user's correction, and the model revises its numbers.
 
     Returns the estimate WITHOUT saving it; the client confirms/edits before
     calling log_estimate.
@@ -349,13 +381,20 @@ def estimate(request: HttpRequest) -> JsonResponse:
         image = request.FILES.get("image")
         text = request.POST.get("text", "").strip()
         note = request.POST.get("note", "").strip()
+        previous_estimate, correction = get_refinement_params(request)
 
         if image is not None:
             result = estimation.estimate_from_image(
-                image.read(), image.content_type or "", note
+                image.read(),
+                image.content_type or "",
+                note,
+                previous_estimate=previous_estimate,
+                correction=correction,
             )
         elif text:
-            result = estimation.estimate_from_text(text)
+            result = estimation.estimate_from_text(
+                text, previous_estimate=previous_estimate, correction=correction
+            )
         else:
             return JsonResponse(
                 {"success": False, "error": "Provide an image or text."}, status=400
@@ -394,7 +433,13 @@ def estimate_recipe(request: HttpRequest) -> JsonResponse:
                 status=400,
             )
 
-        result = estimation.estimate_recipe(recipe_text, fraction)
+        previous_estimate, correction = get_refinement_params(request)
+        result = estimation.estimate_recipe(
+            recipe_text,
+            fraction,
+            previous_estimate=previous_estimate,
+            correction=correction,
+        )
         return JsonResponse({"success": True, "estimate": result.to_dict()})
     except ValueError as e:
         return JsonResponse({"success": False, "error": str(e)}, status=400)


### PR DESCRIPTION
## Feature

After any estimate (text, photo, or recipe), the confirm card now has an inline correction field — "Wrong or missing something? Add details…" — with an **Update** button. Typing a correction like "that was two slices, and there was ranch on it" re-runs the estimate as a two-shot conversation and refreshes the card with revised numbers. You can update repeatedly before hitting "Log it".

This also fixes the take-a-photo flow: the camera option submits immediately with no chance to type anything, so there was previously no way to add context to a photo. Now the context goes in *after* the first estimate comes back.

## How it works

- The client remembers the last request (text, the resized photo blob, or recipe + fraction) plus the estimate it produced. A correction replays the original input with two extra fields: `correction` and `previous_estimate` (JSON).
- The backend rebuilds a genuine three-turn conversation: original user request → assistant turn restating the prior estimate → user correction asking for a revised `record_estimate` call. For photos the image is resent, so "the salad in the photo also had ranch" works against the actual image.
- The two refinement fields are optional on the existing `/estimate/` and `/estimate-recipe/` endpoints but must arrive together; a lone correction, lone previous estimate, or malformed JSON returns a 400.

## Testing

- 13 new tests: conversation shape (three turns, image resent, recipe fraction preserved), fresh estimates staying single-turn, view-level pass-through, and the 400 paths
- Full suite: 146 tests pass
- Live round trip: "I ate a burrito" → 1000 cal, then correction "super burrito with extra cheese and guac, plus chips" → 1730 cal with the guac, extra cheese, and chips itemized

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6NgmyBo3ZxUe92pVUfmh6