### PR TITLE
Revise bio copy

### DIFF
--- a/bio/bio.md
+++ b/bio/bio.md
@@ -1,12 +1,15 @@
 I’m Paul Carroll. I’m a computer scientist and aspiring author living in San Rafael, California.
 
-I’ve spent most of my career programming robots at companies that mostly don’t exist anymore. I’ve
+I’ve spent much of my career programming robots at companies that mostly don’t exist anymore. I’ve
 written software that pilots [high-altitude balloons](https://en.wikipedia.org/wiki/Loon_LLC),
 [self-driving cars](https://en.wikipedia.org/wiki/Waymo),
 [workplace security robots](https://www.youtube.com/watch?v=6PyUjK7JX_c), and
-[robotic arms](https://en.wikipedia.org/wiki/Covariant_%28company%29). Since 2024, I’ve worked at
-Anthropic on the problem of how data is encoded into Claude: tokens, prompt shapes, that sort of
-thing.
+[robotic arms](https://en.wikipedia.org/wiki/Covariant_%28company%29). Robots are great, and I’d
+like to work on them again someday.
+
+Since 2024, I’ve worked at Anthropic on the problem of how data is encoded into Claude: tokens,
+prompt shapes, that sort of thing. I feel great excitement and great apprehension about AI and where
+the world is going. I hope we can get it right.
 
 I graduated from Stanford with degrees in computer science and history and a creative writing minor.
 In my free time, I write historically-flavored fantasy novels and stories.
@@ -14,6 +17,6 @@ In my free time, I write historically-flavored fantasy novels and stories.
 As of August 1, 2025, I also have a son named Wallace who is much cuter and more charismatic than I
 am.
 
-- Link to my [music reviews](https://paulcarroll.site/music/), which I mostly don’t write anymore
-- Link to my [LinkedIn](https://www.linkedin.com/in/paul-carroll-b38592a6/)
-- Link to my [Github](https://github.com/vpcarroll15) (not very interesting)
+- [Music reviews](https://paulcarroll.site/music/)
+- [LinkedIn](https://www.linkedin.com/in/paul-carroll-b38592a6/)
+- [GitHub](https://github.com/vpcarroll15) (not very interesting, but has the code for this website)


### PR DESCRIPTION
## Summary
Follow-up to #159, which was merged before this commit was pushed (supersedes #160, which had conflicts from the squash merge). Applies the bio copy revisions:
- Splits the robots/Anthropic material into two paragraphs, adds the "Robots are great" line and the AI excitement/apprehension paragraph
- "most of my career" → "much of my career"
- Consistent curly apostrophes throughout
- "Music reviews" capitalization and "GitHub" spelling in the links list

## Test plan
- [x] `python manage.py test bio` passes (rendered-link assertions unaffected)
- [x] Pre-commit hooks (incl. prettier wrapping) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sZzWGHixsHQtCzvgki4tD