### PR TITLE
Add a contact email to the bio page

### DIFF
--- a/bio/static/bio/css/styles.css
+++ b/bio/static/bio/css/styles.css
@@ -77,7 +77,14 @@ body {
   margin-bottom: 0.5rem;
 }
 
-.bio-text a {
+.bio-contact {
+  margin: 0.5rem 0 0;
+  color: var(--bio-ink-muted);
+  font-size: 1.02rem;
+}
+
+.bio-text a,
+.bio-contact a {
   color: var(--bio-accent);
   text-decoration: underline;
   text-decoration-color: var(--bio-rule);
@@ -85,7 +92,8 @@ body {
   transition: text-decoration-color 0.15s ease;
 }
 
-.bio-text a:hover {
+.bio-text a:hover,
+.bio-contact a:hover {
   text-decoration-color: var(--bio-accent);
 }
 

--- a/bio/templates/bio/bio.html
+++ b/bio/templates/bio/bio.html
@@ -32,6 +32,20 @@
     <div class="bio-text">
       {{ bio_html }}
     </div>
+    <p class="bio-contact">
+      Get in touch: <a id="contact-link"></a><noscript>vpcarroll15+site [at] gmail [dot] com</noscript>
+    </p>
+    <script>
+      // Assembled at load time so the address doesn't appear in the page source for scrapers.
+      (function () {
+        var user = "vpcarroll15" + "+" + "site";
+        var domain = "gmail" + "." + "com";
+        var address = user + "@" + domain;
+        var link = document.getElementById("contact-link");
+        link.href = "mailto:" + address;
+        link.textContent = address;
+      })();
+    </script>
   </main>
 </body>
 </html>

--- a/bio/templates/bio/bio.html
+++ b/bio/templates/bio/bio.html
@@ -33,7 +33,7 @@
       {{ bio_html }}
     </div>
     <p class="bio-contact">
-      Get in touch: <a id="contact-link"></a><noscript>vpcarroll15+site [at] gmail [dot] com</noscript>
+      Get in touch: <a id="contact-link"></a><noscript>my email address is my GitHub username, plus the tag &ldquo;+site&rdquo;, at Google&rsquo;s mail service</noscript>
     </p>
     <script>
       // Assembled at load time so the address doesn't appear in the page source for scrapers.

--- a/bio/tests.py
+++ b/bio/tests.py
@@ -24,6 +24,15 @@ class BioViewTests(TestCase):
         self.assertContains(response, "https://github.com/vpcarroll15")
         self.assertContains(response, "https://paulcarroll.site/music/")
 
+    def test_contact_section_present_without_scrapable_email(self) -> None:
+        response = self.client.get("/")
+        self.assertContains(response, "Get in touch")
+        # The address is assembled by JavaScript at load time; the raw address
+        # (and any mailto: link) must never appear in the page source.
+        self.assertNotContains(response, "vpcarroll15+site@gmail.com")
+        self.assertNotContains(response, "vpcarroll15@gmail.com")
+        self.assertNotContains(response, "mailto:v")
+
     def test_bio_markdown_file_missing_returns_404(self) -> None:
         with patch("bio.views.BIO_MARKDOWN_PATH", "bio/does_not_exist.md"):
             response = self.client.get("/")


### PR DESCRIPTION
## Summary
- Adds a "Get in touch" line under the bio links with a `mailto:` link to `vpcarroll15+site@gmail.com` (plus-addressed for filtering and leak tracing)
- The address is assembled by a few lines of JavaScript at load time, so neither the address nor any `mailto:` appears in the page source — most scrapers don't execute JS
- `<noscript>` fallback shows a munged, human-decodable version
- Muted styling consistent with the links list

## Test plan
- [x] New test asserts "Get in touch" renders and that the raw address / `mailto:` never appears in the page source (5 bio tests pass)
- [x] Verified the JS assembles `mailto:vpcarroll15+site@gmail.com` correctly by executing it in node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sZzWGHixsHQtCzvgki4tD